### PR TITLE
25ji-Nightcord: Add card background-color on Cover & lyrics

### DIFF
--- a/src/components/Card.module.scss
+++ b/src/components/Card.module.scss
@@ -20,6 +20,8 @@
 		display: none;
 	}
 	&.filled {
+		background-color: var(--md-sys-color-surface-container-highest);
+		color: var(--md-sys-color-on-surface-variant);
 		&:hover {
 			&::before {
 				opacity: 0.08;


### PR DESCRIPTION
* looks like this was removed in v1 changes

reference: https://github.com/Natsuno-Shosetsu/renzalt-music/commit/339922b6300bf4cb44f14970b06d9422cb71b0a2